### PR TITLE
Add nodeports services 

### DIFF
--- a/.argo/argo-nodeport-svc.yaml
+++ b/.argo/argo-nodeport-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-server-nodeport
+  namespace: argo
+spec:
+  ports:
+  - name: web
+    port: 2746
+    protocol: TCP
+    targetPort: 2746
+    nodePort: 32009
+  selector:
+    app: argo-server
+  sessionAffinity: None
+  type: NodePort

--- a/.argo/argocd-nodeport-svc.yaml
+++ b/.argo/argocd-nodeport-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server-nodeport
+  namespace: argocd
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+    nodePort: 32008
+  selector:
+    app.kubernetes.io/name: argocd-server
+  sessionAffinity: None
+  type: NodePort
+


### PR DESCRIPTION
This nodeport services allow access to argo & argocd UI without need of port-forward.
The argo is listening on port 32008 .
The argocd is listening on port 32009.
TODO: Add https://localhost:32008 for argo and https://localhost:32009 for argocd to the readme.